### PR TITLE
Prevent remove @version/@timstamp fields from event.

### DIFF
--- a/lib/logstash/outputs/cassandra/event_parser.rb
+++ b/lib/logstash/outputs/cassandra/event_parser.rb
@@ -70,11 +70,8 @@ module LogStash; module Outputs; module Cassandra
     end
 
     def add_event_data_using_configured_hints(event, action)
-      action_data = {}
-      event.to_hash.each do |key, value|
-        action_data[key] = value unless %r{^@} =~ key
-      end
-
+      action_data = event.to_hash.reject { |key| %r{^@} =~ key }
+      
       @hints.each do |event_key, cassandra_type|
         if action_data.has_key?(event_key)
           action_data[event_key] = convert_value_to_cassandra_type_or_default_if_configured(action_data[event_key], cassandra_type)

--- a/lib/logstash/outputs/cassandra/event_parser.rb
+++ b/lib/logstash/outputs/cassandra/event_parser.rb
@@ -70,9 +70,11 @@ module LogStash; module Outputs; module Cassandra
     end
 
     def add_event_data_using_configured_hints(event, action)
-      action_data = event.to_hash
-      # Filter out @timestamp, @version, etc to be able to use elasticsearch input plugin directly
-      action_data.reject!{|key| %r{^@} =~ key}
+      action_data = {}
+      event.to_hash.each do |key, value|
+        action_data[key] = value unless %r{^@} =~ key
+      end
+
       @hints.each do |event_key, cassandra_type|
         if action_data.has_key?(event_key)
           action_data[event_key] = convert_value_to_cassandra_type_or_default_if_configured(action_data[event_key], cassandra_type)


### PR DESCRIPTION
I found that attribute @version & @timetamp of data are removed after this output and affect following plugins, so I created a new hash for action and re-assign instead of using event.to_hash .
